### PR TITLE
Updated README with Sendgrid API key requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can now choose to build via command line, or use Xcode. Who doesn't love Xco
 You will need to add some API keys as environment variables for the project to run successfully. If you're using Xcode, you can do it from the scheme menu. If you're not using Xcode, define them as environment variables. Here are the required variables:
 
 - `STRIPE_API_KEY` can be any non-empty string.
+- `SENDGRID_API_KEY` can be any non-empty string.
 - `DB_HOSTNAME`, `DB_USER`, `DB_PASSWORD`, `DB_DATABASE` should point to the PostgreSQL database that you have created locally. Only creating the database should be enough, Vapor will take care of generating all the needed tables when compiled for the first time.
 
 ## Architecture


### PR DESCRIPTION
I noticed this when I pulled down the most recent changes for the project.  Just adding a note for the need of a SendGrid API key environment variable now when running it locally.